### PR TITLE
Fix npm published package so it uses declarations instead of a source file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 index.js
 index.test.js
 *.map
+dist

--- a/index.ts
+++ b/index.ts
@@ -23,7 +23,7 @@ export function createAction<TPayload>(type: string): ActionDefinition<TPayload>
   return actionCreator;
 }
 
-interface ReducerHandler<TState, TAction> {
+export interface ReducerHandler<TState, TAction> {
   (state: TState, action: TAction): TState;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
   "name": "redux-ts-simple",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Yet another lib for creating typed actions and reducers.",
-  "main": "index.js",
+  "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
   "scripts": {
+    "build": "tsc",
+    "build:watch": "tsc --watch",
     "test": "jest"
   },
   "repository": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "outDir": "dist",
     "noImplicitAny": true,
     "noEmitOnError": true,
     "removeComments": false,
@@ -9,7 +10,8 @@
     "moduleResolution": "node",
     "strictNullChecks": true,
     "pretty": true,
-    "allowSyntheticDefaultImports": false
+    "allowSyntheticDefaultImports": false,
+    "declaration": true
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
This is the standard way of publishing a TS library (i.e. publishing a .d.ts instead of a .ts file). Otherwise the TS compiler will sometimes complain about having a source file outside the source root.